### PR TITLE
switch from TRANSCRIPT to PDF-TRANSCRIPT to prevent collision with is…

### DIFF
--- a/includes/oh_upload.form.inc
+++ b/includes/oh_upload.form.inc
@@ -176,12 +176,12 @@ function islandora_oh_oh_upload_form_submit(array $form, array &$form_state) {
     }
   }
   if ($form_state['values']['transcript_pdf']) {
-    if (empty($object['TRANSCRIPT'])) {
-      $obj = $object->constructDatastream('TRANSCRIPT', 'M');
+    if (empty($object['PDF-TRANSCRIPT'])) {
+      $obj = $object->constructDatastream('PDF-TRANSCRIPT', 'M');
       $object->ingestDatastream($obj);
     }
     else {
-      $obj = $object['TRANSCRIPT'];
+      $obj = $object['PDF-TRANSCRIPT'];
     }
     $index_file = file_load($form_state['values']['transcript_pdf']);
     $obj->setContentFromFile(drupal_realpath($index_file->uri), FALSE);

--- a/islandora_oh.module
+++ b/islandora_oh.module
@@ -142,7 +142,7 @@ function islandora_oh_preprocess_islandora_oh(array &$variables) {
   }
   // Borrowing from PDF.
   module_load_include('inc', 'islandora', 'includes/solution_packs');
-  $viewer = islandora_get_viewer(array('dsid' => 'TRANSCRIPT'), 'islandora_pdf_viewers', $islandora_object);
+  $viewer = islandora_get_viewer(array('dsid' => 'PDF-TRANSCRIPT'), 'islandora_pdf_viewers', $islandora_object);
 
   $variables['transcript_pdf'] = $viewer ? $viewer : '';
   if (isset($islandora_object['INDEX']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['INDEX'])) {

--- a/xml/islandora_oh_ds_composite_model.xml
+++ b/xml/islandora_oh_ds_composite_model.xml
@@ -31,7 +31,7 @@
   <dsTypeModel ID="INDEX" optional="true">
     <form MIME="application/pdf"></form>
   </dsTypeModel>
-  <dsTypeModel ID="TRANSCRIPT" optional="true">
+  <dsTypeModel ID="PDF-TRANSCRIPT" optional="true">
     <form MIME="application/pdf"></form>
   </dsTypeModel>
   <dsTypeModel ID="TECHMD">


### PR DESCRIPTION
If other institutions end up using our OralHistory module & NickReust's Transcript module,  they will collide unless he accepts our pull request.  Since we control the OralHistory module & nothing depends on using this particular variablename, we can change our variable to avoid the collision.

What I did was replace and "TRANSCRIPT" in our code with "PDF-TRANSCRIPT".  It 99% certain works, but it'd be good to checkout this branch on an example of an oral-history collection to make sure that 1% isn't happening.